### PR TITLE
feat: inventory full duplicate message fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'net.mackenziemolloy.shopguiplus.sellgui'
-version '1.1.8'
+version '1.1.9'
 
 java {
     toolchain {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'net.mackenziemolloy.shopguiplus.sellgui'
-version '1.1.9'
+version '1.1.8'
 
 java {
     toolchain {

--- a/src/main/java/net/mackenziemolloy/shopguiplus/sellgui/command/CommandSellGUI.java
+++ b/src/main/java/net/mackenziemolloy/shopguiplus/sellgui/command/CommandSellGUI.java
@@ -362,7 +362,7 @@ public final class CommandSellGUI implements TabExecutor {
 
         double totalPrice = 0;
         int itemAmount = 0;
-        boolean excessItems = false;
+        List<ItemStack> droppedItems = new ArrayList<>();
         boolean itemsPlacedInGui = false;
 
         Inventory inventory = event.getInventory();
@@ -408,19 +408,17 @@ public final class CommandSellGUI implements TabExecutor {
                 double amountSold2 = (totalSold2 + itemSellPrice);
                 moneyMap.put(itemEconomyType, amountSold2);
             } else {
-                excessItems = true;
-
-                Location location = player.getLocation().add(0.0D, 0.5D, 0.0D);
                 Map<Integer, ItemStack> fallenItems = event.getPlayer().getInventory().addItem(i);
-                scheduler.runAtLocation(location, task -> {
-                    World world = player.getWorld();
-                    fallenItems.values().forEach(item -> world.dropItemNaturally(location, item));
-                });
+                droppedItems.addAll(fallenItems.values());
             }
         }
 
-        if (excessItems) {
+        if (!droppedItems.isEmpty()) {
             sendMessage(player, "inventory_full");
+            Location location = player.getLocation().add(0.0D, 0.5D, 0.0D);
+            World world = location.getWorld();
+            scheduler.runAtLocation(location, task ->
+                    droppedItems.forEach(item -> world.dropItemNaturally(location, item)));
         }
 
         if (totalPrice == 0) {


### PR DESCRIPTION
This patches a minor visual issue with the error message regarding a full inventory when selling an unsellable item.

**What's the issue?**
The /sellgui function gives an incorrect error message when attempting to place an unsellable item into the GUI. It says the player’s inventory is full and excess items were dropped on the ground, even when the inventory has plenty of empty space.

**Steps to reproduce:**

Open /sellgui.
Have empty inventory slots available.
Attempt to place an unsellable item into the sell GUI.
Observe the message:
“Shop > Your inventory is currently full, so excess items have been dropped on the ground.”

**Expected result:**

The GUI should either:

reject the item with a message stating the item is unsellable, or
return the item normally without claiming the inventory is full.

**Actual result:**

The system displays an inventory full message and claims items were dropped, even when the player has available inventory space.

**What's this PR do?**
Patches that! :D

Credit to @Tarmk for the original issue report in our servers' discord